### PR TITLE
Small updates to punctuation editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 node_modules/
+.existdb.json
+*.code-workspace

--- a/api/save_ratings.xql
+++ b/api/save_ratings.xql
@@ -18,6 +18,7 @@ declare variable $userhome := "/db/users/";
 let $textid-in := request:get-parameter("textid", "xx"),
 $textid := substring-after($textid-in, "input-") 
 let $rating := request:get-parameter("rating", "xx")
+let $is-delete := request:get-parameter("delete", "n") = "y"
 let $user := sm:id()//sm:real/sm:username/text()
 let $usercoll := $userhome || $user 
 let $ratingsfile := "/ratings.xml",
@@ -31,7 +32,13 @@ let $doc := if (doc-available($usercoll || $ratingsfile )) then doc($usercoll ||
 let $newnode := <text id="{$textid}" rating="{$rating}">{$title}</text>,
 $currentnode := $doc//text[@id=$textid]
 return 
-if ($currentnode) then
-update replace $currentnode with $newnode
-else
-update insert $newnode into $doc/textlist
+    if ($is-delete) then
+        if ($currentnode) then
+            update delete $currentnode
+        else
+            ()
+    else
+        if ($currentnode) then
+            update replace $currentnode with $newnode
+        else
+            update insert $newnode into $doc/textlist

--- a/api/tlsapi.xql
+++ b/api/tlsapi.xql
@@ -1697,39 +1697,38 @@ seg = Punctuated text, must be passed in plain text in the body of the request
 cont = 'false' or 'true'; when true display the dialog again with the next segment
 type = one of the seg-types, defined in config.xqm
 :)
-
 declare function tlsapi:save-punc($map as map(*)){
 let  $seg := collection($config:tls-texts-root)//tei:seg[@xml:id=$map?line_id]
-, $new-seg := util:base64-decode(request:get-data())
+, $new-seg := util:base64-decode(request:get-data()) 
 , $r0 := tlslib:proc-seg-for-edit($seg) => string-join('') => normalize-space() => replace(' ', '') => tokenize('\$')
 , $r1 := tokenize($new-seg, '\$')
 , $res := string-join(for $r at $pos in tokenize($new-seg, '\$') return $r || "$" || $pos || "$", '')
 , $str := analyze-string ($res, $config:seg-split-tokens)
 return
-if (count($r0) != count($r1)) then "Error: Text integrity check failed. Can not save edited text. " ||$r0 || "," || $r1
-else
-    let $seg-with-updated-type :=
-    if ($map?type != $seg/@type) then
+if (count($r0) != count($r1)) then "Error: Text integrity check failed. Can not save edited text."
+else 
+    let $seg-with-updated-type := 
+    if ($map?type != $seg/@type) then 
         let $res := xed:change-seg-type($seg, $map?type)
         , $p := $seg/parent::*
         return ()
     else
         ()
     return
-    if ($map?action = "no_split") then
-        let $tx := tlslib:add-nodes($res, $seg/child::*[not(self::tei:c)])
+    if ($map?action = "no_split") then 
+        let $tx := tlslib:add-nodes($res, $seg//node())
         , $segs := <seg xmlns="http://www.tei-c.org/ns/1.0" xml:id="{$map?line_id}" type="{$map?type}">{$tx}</seg>
         return update replace $seg with $segs
-    else
+    else 
         let $segs := for $m at $pos in $str//fn:non-match
             let $nm := $m/following-sibling::fn:*[1]
             , $t := replace(string-join($nm/text(), ''), '/', '')
             , $tx := tlslib:add-nodes($m/text(), $seg/child::*[not(self::tei:c)])
-            , $sl := string-join($tx, '') => normalize-space() => replace(' ', '')
-            , $nid := if ($pos > 1) then $map?line_id ||"." || ($pos - 1) else $map?line_id
+            , $sl := string-join($tx, '') => normalize-space() => replace(' ', '') 
+            , $nid := if ($pos > 1) then tlslib:generate-new-line-id($map?line_id , $pos - 1) else $map?line_id 
             where string-length($sl) > 0
             return
-            <seg xmlns="http://www.tei-c.org/ns/1.0" xml:id="{$nid}" type="{$map?type}">{$tx,
+            <seg xmlns="http://www.tei-c.org/ns/1.0" xml:id="{$nid}" type="{$map?type}">{$tx, 
                 if (local-name($nm) = 'match' and string-length($t) > 0) then <c n="{$t}"/> else ()}</seg>
         return (
         if (count($segs) > 1) then

--- a/api/tlsapi.xql
+++ b/api/tlsapi.xql
@@ -1745,14 +1745,15 @@ declare function tlsapi:merge-following-seg($map as map(*)){
 let $segid := $map?line_id,
     $new-seg :=  $map?body,
     $seg := collection($config:tls-texts-root)//tei:seg[@xml:id=$segid]
-return 
-    if (not(tlslib:check-edited-seg-valid($new-seg, $seg))) then "Error: Text integrity check failed. Can not save edited text."
-    else
-        let $save-punc-rst := tlsapi:save-punc(map:put($map, "action", "no_split")) 
-        (: Use save-punc to update the edited part, without splitting. :),
+return
+    if ($new-seg = ()) then "Error: Please use the function under 內部 to completely delete segment" 
+    else if (not(tlslib:check-edited-seg-valid($new-seg, $seg))) then "Error: Text integrity check failed. Can not save edited text."
+    else 
+        (: Use save-punc to update the edited part, without splitting. :)
+        let $save-punc-rst := tlsapi:save-punc(map:put($map, "action", "no_split")),
             $updated-seg := collection($config:tls-texts-root)//tei:seg[@xml:id=$segid],
-            $fseg := $seg/following::tei:seg[1],
-            $nseg := <seg xmlns="http://www.tei-c.org/ns/1.0" xml:id="{$seg/@xml:id}" type="{$map?type}">{$seg/node(), $fseg/node()}</seg> 
+            $fseg := $updated-seg/following::tei:seg[1],
+            $nseg := <seg xmlns="http://www.tei-c.org/ns/1.0" xml:id="{$segid}" type="{$map?type}">{$updated-seg/node(), $fseg/node()}</seg>
         return (
             update replace $seg with $nseg, 
             update delete $fseg

--- a/api/tlsapi.xql
+++ b/api/tlsapi.xql
@@ -19,7 +19,7 @@ import module namespace tlslib="http://hxwd.org/lib" at "../modules/tlslib.xql";
 import module namespace dialogs="http://hxwd.org/dialogs" at "../modules/dialogs.xql"; 
 import module namespace krx="http://hxwd.org/krx-utils" at "../modules/krx-utils.xql";
 import module namespace xed="http://hxwd.org/xml-edit" at "../modules/xml-edit.xql";
-import module namespace imp="http://hxwd.org/xml-import"at "../modules/import.xql"; 
+import module namespace imp="http://hxwd.org/xml-import" at "../modules/import.xql"; 
 
 declare namespace tei= "http://www.tei-c.org/ns/1.0";
 declare namespace tls="http://hxwd.org/ns/1.0";
@@ -1748,7 +1748,8 @@ let $segid := $map?line_id,
 return 
     if (not(tlslib:check-edited-seg-valid($new-seg, $seg))) then "Error: Text integrity check failed. Can not save edited text."
     else
-        let $save-punc-rst := tlsapi:save-punc(map:put($map, "action", "no_split")) (: Use save-punc to update the edited part, wihtout splitting. :),
+        let $save-punc-rst := tlsapi:save-punc(map:put($map, "action", "no_split")) 
+        (: Use save-punc to update the edited part, without splitting. :),
             $updated-seg := collection($config:tls-texts-root)//tei:seg[@xml:id=$segid],
             $fseg := $seg/following::tei:seg[1],
             $nseg := <seg xmlns="http://www.tei-c.org/ns/1.0" xml:id="{$seg/@xml:id}" type="{$map?type}">{$seg/node(), $fseg/node()}</seg> 

--- a/modules/tlslib.xql
+++ b/modules/tlslib.xql
@@ -3085,3 +3085,20 @@ default
 return <name>{$node}</name>
 };
 
+(: Generate a fresh xml:id for a segment based on some base line id that an index is appended to. 
+ : If appending the index results in an id that is already present in the database, the level
+ : parameter is also appended to the id. The level argument will be increased until a
+ : id that is not present in the database is found. :)
+declare function tlslib:generate-new-line-id($base-id as xs:string, $index as xs:int, $level as xs:int) as xs:string {
+    let $nid := $base-id || "." || $index || (if ($level = 0) then "" else "_" || $level)
+    return
+        if (collection($config:tls-texts-root)//tei:seg[@xml:id=$nid]) then
+            tlslib:generate-new-line-id($base-id, $index, $level + 1)
+        else
+            $nid
+};
+
+(: Just like the above function, with $level set to 0 as a default. :)
+declare function tlslib:generate-new-line-id($base-id as xs:string, $index as xs:int) as xs:string {
+    tlslib:generate-new-line-id($base-id, $index, 0)
+};

--- a/modules/tlslib.xql
+++ b/modules/tlslib.xql
@@ -2911,7 +2911,7 @@ typeswitch ($node)
  : parameter is also appended to the id. The level argument will be increased until a
  : id that is not present in the database is found. :)
 declare function tlslib:generate-new-line-id($base-id as xs:string, $index as xs:int, $level as xs:int) as xs:string {
-    let $nid := $base-id || "." || $index || (if ($level = 0) then "" else "_" || $level)
+    let $nid := $base-id || "." || $index || (if ($level = 0) then "" else "." || $level)
     return
         if (collection($config:tls-texts-root)//tei:seg[@xml:id=$nid]) then
             tlslib:generate-new-line-id($base-id, $index, $level + 1)

--- a/resources/scripts/tls-webapp.js
+++ b/resources/scripts/tls-webapp.js
@@ -2088,7 +2088,7 @@ function save_punc(line_id, next){
     var url = "api/responder.xql?func=merge-following-seg&line_id="+line_id+"&type="+type;
     next = line_id;
   } else if (next == 'no_split') {
-    var url = "api/responder.xql?func=merge-following-seg&line_id="+line_id+"&type="+type+"&action="+next;
+    var url = "api/responder.xql?func=save-punc&line_id="+line_id+"&type="+type+"&action="+next;
     next = "";
   } else {
     var url = "api/responder.xql?func=save-punc&line_id="+line_id+"&type="+type;

--- a/resources/scripts/tls-webapp.js
+++ b/resources/scripts/tls-webapp.js
@@ -948,6 +948,22 @@ $('.rating').on('rating:change', function(event, value, caption) {
   }
  });
 });
+// save deletion of ratings of the texts
+$('.rating').on('rating:clear', function(event, value, caption) {
+        console.log(value);
+        console.log(this.id);
+  $.ajax({
+  type : "PUT",
+  url : "api/save_ratings.xql?textid="+this.id+"&delete=y",
+  success : function(resp){
+    toastr.info("Your rating has been cleared.", "HXWD says:")
+  },
+  error : function(resp){
+    console.log(resp)
+    alert(resp);
+  }
+ });
+});
 // ratings for the SWL ratings
 $('.starRating').on('click', function(event, value, caption) {
         console.log(value);
@@ -2072,7 +2088,7 @@ function save_punc(line_id, next){
     var url = "api/responder.xql?func=merge-following-seg&line_id="+line_id+"&type="+type;
     next = line_id;
   } else if (next == 'no_split') {
-    var url = "api/responder.xql?func=save-punc&line_id="+line_id+"&type="+type+"&action="+next;
+    var url = "api/responder.xql?func=merge-following-seg&line_id="+line_id+"&type="+type+"&action="+next;
     next = "";
   } else {
     var url = "api/responder.xql?func=save-punc&line_id="+line_id+"&type="+type;
@@ -2090,8 +2106,7 @@ function save_punc(line_id, next){
   if (next.length > 1){
       display_punc_dialog(next)
   } else {
-//    console.log("not reloading")
-     window.location.reload(true)
+      window.location.reload(true)
   }
   },
   error : function(resp){
@@ -2100,6 +2115,8 @@ function save_punc(line_id, next){
   }
   });      
 };
+
+
 
 window.onbeforeunload = function() {
     return dirty ? "If you leave this page you will lose your unsaved changes." : null;


### PR DESCRIPTION
- Added functionality to remove ratings for texts
- Added function in tlslib to create new segment id, ensuring that it is globally unique
- New behavior when merging with following segment: first, save, updates to current segment without splitting; then merge with the following segment
(Needs testing)