### PR TITLE
Logging module and related files

### DIFF
--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -45,6 +45,7 @@ declare variable $config:tls-texts-root := substring-before($config:app-root, da
 declare variable $config:tls-krx-root := substring-before($config:app-root, data($config:expath-descriptor/@abbrev)) || "tls-krx";
 declare variable $config:tls-translation-root := concat($config:tls-data-root, "/translations");
 declare variable $config:tls-user-root := "/db/users/";
+declare variable $config:tls-log-collection := "/db/users/tls-admin/logs";
 declare variable $config:tls-add-titles := $config:tls-texts-root || "/krp-titles.xml";
 declare variable $config:exide-url := "/exist/apps/eXide/index.html";
 declare variable $config:tls-manifests := 

--- a/modules/db-utility.xqm
+++ b/modules/db-utility.xqm
@@ -1,0 +1,93 @@
+xquery version "3.1";
+
+module namespace dbu="http://exist-db.org/xquery/utility/db";
+
+import module namespace config="http://exist-db.org/xquery/apps/config" at "repo-config.xqm";
+
+declare variable $dbu:default-permissions := config:repo-permissions();
+
+(:~
+ : create collection(s) if they do not exist
+ : any newly created collection will have the package-permissions set
+ : will throw an error if the current user does not have the appropriate rights
+ :
+ : @param $path xs:string
+ : @returns the path that was entered
+ :)
+declare
+function dbu:ensure-collection($path as xs:string) as xs:string {
+    if (xmldb:collection-available($path))
+    then $path
+    else
+        tokenize($path, "/")
+        => tail() 
+        => fold-left("", dbu:create-collection-with-repo-permissions#2)
+};
+
+(:~
+ : create collection(s) if they do not exist
+ : any newly created collection will have the permissions given in the second parameter
+ : will throw an error if the current user does not have the appropriate rights
+ :
+ : @param $path xs:string
+ : @param $permissions map(xs:string, xs:string) with "owner", "group", "mode"
+ : @returns the path that was entered
+ :)
+declare
+function dbu:ensure-collection($path as xs:string, $permissions as map(*)) as xs:string {
+    if (xmldb:collection-available($path))
+    then $path
+    else
+        tokenize($path, "/")
+        => tail() 
+        => fold-left("", dbu:create-collection(?, ?, $permissions))
+};
+
+(:~
+ : set owner, group and mode for a collection or resource to package defaults
+ : will throw an error, if the current user does not have the appropriate rights
+ :
+ : @param $resource-or-collection xs:string
+ : @returns the path that was entered
+ :)
+declare 
+function dbu:set-repo-permissions ($resource-or-collection as xs:string) as xs:string {
+    dbu:set-permissions($resource-or-collection, $dbu:default-permissions)
+};
+
+(:~
+ : set owner, group and mode for a collection or resource
+ : will throw an error, if the current user does not have the appropriate rights
+ :
+ : @param $resource-or-collection xs:string
+ : @param $permissions map(xs:string, xs:string) with "owner", "group", "mode"
+ : @returns the path that was entered
+ :)
+declare 
+function dbu:set-permissions ($resource-or-collection as xs:string, $permissions as map(*)) as xs:string {
+    sm:chown($resource-or-collection, $permissions?owner),
+    sm:chgrp($resource-or-collection, $permissions?group),
+    sm:chmod(xs:anyURI($resource-or-collection), $permissions?mode),
+    $resource-or-collection
+};
+
+declare 
+    %private
+function dbu:create-collection-with-repo-permissions ($collection as xs:string, $next as xs:string) as xs:string {
+    if (xmldb:collection-available(concat($collection, '/', $next)))
+    then concat($collection, '/', $next)
+    else
+        xmldb:create-collection($collection, $next)
+        => dbu:set-repo-permissions()
+};
+
+
+declare 
+    %private
+function dbu:create-collection ($collection as xs:string, $next as xs:string, $permissions as map(*)) as xs:string {
+    if (xmldb:collection-available(concat($collection, '/', $next)))
+    then concat($collection, '/', $next)
+    else
+        xmldb:create-collection($collection, $next)
+        => dbu:set-permissions($permissions)
+};

--- a/modules/git-sync.xql
+++ b/modules/git-sync.xql
@@ -1,0 +1,27 @@
+xquery version "3.1";
+import module namespace http="http://expath.org/ns/http-client";
+import module namespace ghx="http://exist-db.org/lib/githubxq";
+import module namespace log="http://hxwd.org/log" at "log.xql";
+import module namespace config="http://hxwd.org/config" at "config.xqm";
+
+declare variable $git-config := if(doc('../access-config.xml')) then doc('../access-config.xml') else <response status="fail"><message>Load config.xml file please.</message></response>;
+
+declare variable $gitSecret := if($git-config//gitToken-variable != '') then 
+                                    environment-variable($git-config//gitToken-variable/text())
+                              else $git-config//gitToken/text();
+declare variable $gitKey := if($git-config//private-key-variable != '') then 
+                                    environment-variable($git-config//private-key-variable/text())
+                              else $git-config//private-key/text();
+declare variable $exist-collection := $git-config//exist-collection/text();
+
+(: Github repository :)
+declare variable $repo-name := $git-config//repo-name/text();
+                              
+declare variable $git-log := $config:tls-log-collection || "/git";
+
+let $data := request:get-data()
+let $file-data := ghx:execute-webhook($data, $exist-collection, $repo-name, "master",  $gitSecret, $gitKey)
+
+
+
+return for $f in $file-data return log:info($git-log, $f)

--- a/modules/log.xql
+++ b/modules/log.xql
@@ -1,0 +1,181 @@
+xquery version "3.1";
+(:~
+: This module provides the internal functions that do not directly control the 
+: template driven Web presentation
+: of the TLS. 
+
+: @author Christian Wittern  cwittern@yahoo.com
+: @version 1.0
+
+Based on code by Adam Retter on the exist slack channel
+
+:)
+module namespace log="http://hxwd.org/log";
+import module namespace dbu="http://exist-db.org/xquery/utility/db" at "db-utility.xqm";
+
+(:~
+ : TRACE log level.
+ :)
+declare variable $log:TRACE as xs:integer := 1;
+
+(:~
+ : DEBUG log level.
+ :)
+declare variable $log:DEBUG as xs:integer := 2;
+
+(:~
+ : INFO log level.
+ :)
+declare variable $log:INFO as xs:integer := 3;
+
+(:~
+ : WARN log level.
+ :)
+declare variable $log:WARN as xs:integer := 4;
+
+(:~
+ : ERROR log level.
+ :)
+declare variable $log:ERROR as xs:integer := 5;
+
+
+(:~
+ : XPath Error code for when an invalid log level is used.
+ :)
+declare variable $log:ERROR_INVALID_LEVEL := xs:QName("log:ERROR_INVALID_LEVEL");
+
+(:~
+ : Write a log entry at TRACE level.
+ :
+ : @param $log-collection the collection to hold the log entry.
+ : @param $message the message to write to the log entry.
+ :)
+declare function log:trace($log-collection as xs:string, $message as xs:string) as empty-sequence() {
+  log:message($log-collection, $log:TRACE, $message)
+};
+
+(:~
+ : Write a log entry at DEBUG level.
+ :
+ : @param $log-collection the collection to hold the log entry.
+ : @param $message the message to write to the log entry.
+ :)
+declare function log:debug($log-collection as xs:string, $message as xs:string) as empty-sequence() {
+  log:message($log-collection, $log:DEBUG, $message)
+};
+
+(:~
+ : Write a log entry at INFO level.
+ :
+ : @param $log-collection the collection to hold the log entry.
+ : @param $message the message to write to the log entry.
+ :)
+declare function log:info($log-collection as xs:string, $message as xs:string) as empty-sequence() {
+  log:message($log-collection, $log:INFO, $message)
+};
+
+(:~
+ : Write a log entry at WARN level.
+ :
+ : @param $log-collection the collection to hold the log entry.
+ : @param $message the message to write to the log entry.
+ :)
+declare function log:warn($log-collection as xs:string, $message as xs:string) as empty-sequence() {
+  log:message($log-collection, $log:WARN, $message)
+};
+
+(:~
+ : Write a log entry at ERROR level.
+ :
+ : @param $log-collection the collection to hold the log entry.
+ : @param $message the message to write to the log entry.
+ :)
+declare function log:error($log-collection as xs:string, $message as xs:string) as empty-sequence() {
+  log:message($log-collection, $log:ERROR, $message)
+};
+
+(:~
+ : Write a log entry.
+ :
+ : @param $log-collection the collection to hold the log entry.
+ : @param $level the log level for the log entry.
+ : @param $message the message to write to the log entry.
+ :
+ : @error log:ERROR_INVALID_LEVEL if an invalid level is requested.
+ :)
+declare function log:message($log-collection as xs:string, $level as xs:integer, $message as xs:string) as empty-sequence() {
+  let $status-string := log:get-level-string($level)
+  let $timestamp := util:system-dateTime()
+  let $log-file-path := log:get-or-create-log-file($log-collection, $timestamp)
+  let $log := fn:doc($log-file-path)/log
+  return
+    update insert <entry level="{$status-string}" timestamp="{$timestamp}">{$message}</entry> into $log
+};
+
+(:~
+ : Get the log level as a string.
+ :
+ : @param $level the log level.
+ :
+ : @return a string representation of the log level.
+ :
+ : @error log:ERROR_INVALID_LEVEL if an invalid level is requested.
+ :)
+declare
+  (: %private :) (: NOTE(AR) commented out to make testable with XQSuite :)
+function log:get-level-string($level as xs:integer) as xs:string {
+  switch ($level)
+    case $log:TRACE return "trace"
+    case $log:DEBUG return "debug"
+    case $log:INFO return "info"
+    case $log:WARN return "warn"
+    case $log:ERROR return "error"
+    default return fn:error($log:ERROR_INVALID_LEVEL, "Unknown level: " || $level)
+};
+
+(:~
+ : Get or create a log file.
+ :
+ : @param $log-collection the collection to hold the log file.
+ : @param $timestamp the timestamp for the log file.
+ :
+ : @return the path to the log file.
+ :)
+declare
+  (: %private :) (: NOTE(AR) commented out to make testable with XQSuite :)
+function log:get-or-create-log-file($log-collection as xs:string, $timestamp as xs:dateTime) as xs:string {
+
+  (: Create log collection if it does not exist :)
+  let $_ :=
+      if (not(xmldb:collection-available($log-collection)))
+      then
+         dbu:ensure-collection($log-collection)
+      else()
+
+  (: NOTE(AR) the TimeZone here will be whatever timezone the query is executed in... more specifically it is the timezone of the host system :)
+  let $log-file-name := "log." || fn:format-dateTime($timestamp, "[Y0001][M01][D01]") || ".xml"
+  let $log-file-path := $log-collection || "/" || $log-file-name
+  return
+    if (fn:doc-available($log-file-path))
+    then
+      $log-file-path
+    else
+      log:create-log-file($log-collection, $log-file-name, $timestamp)
+};
+
+(:~
+ : Create a log file.
+ :
+ : @param $log-collection the collection to hold the log file.
+ : @param $log-file-name the name of the log file.
+ : @param $timestamp the timestamp for the log file.
+ :
+ : @return the path to the log file.
+ :)
+declare
+  (: %private :) (: NOTE(AR) commented out to make testable with XQSuite :)
+function log:create-log-file($log-collection as xs:string, $log-file-name as xs:string, $timestamp as xs:dateTime) as xs:string {
+  let $empty-log-file := <log date="{$timestamp cast as xs:date}"/>
+  return
+    xmldb:store($log-collection, $log-file-name, $empty-log-file)
+};

--- a/modules/repo-config.xqm
+++ b/modules/repo-config.xqm
@@ -1,0 +1,114 @@
+xquery version "3.1";
+
+(:~
+ : Configuration options for the application and a set of helper functions to access 
+ : the application context.
+ :)
+
+module namespace config="http://exist-db.org/xquery/apps/config";
+
+declare namespace system="http://exist-db.org/xquery/system";
+
+declare namespace expath="http://expath.org/ns/pkg";
+declare namespace repo="http://exist-db.org/xquery/repo";
+
+
+declare variable $config:login-domain := "org.exist.public-repo.login";
+
+(: Determine the application root collection from the current module load path :)
+declare variable $config:app-root := 
+    let $rawPath := system:get-module-load-path()
+    let $modulePath :=
+        (: strip the xmldb: part :)
+        if (starts-with($rawPath, "xmldb:exist://")) then
+            if (starts-with($rawPath, "xmldb:exist://embedded-eXist-server")) then
+                substring($rawPath, 36)
+            else if (starts-with($rawPath, "xmldb:exist://null")) then
+                substring($rawPath, 19)
+            else
+                substring($rawPath, 15)
+        else
+            $rawPath
+    return
+        substring-before($modulePath, "/modules")
+;
+
+(: Default collection and resource names for binary assets and extracted package metadata :)
+
+declare variable $config:app-data-parent-col := "/db/apps";
+declare variable $config:app-data-col-name := "public-repo-data";
+declare variable $config:packages-col-name := "packages";
+declare variable $config:icons-col-name := "icons";
+declare variable $config:metadata-col-name := "metadata";
+declare variable $config:logs-col-name := "logs";
+
+declare variable $config:app-data-col := $config:app-data-parent-col || "/" || $config:app-data-col-name;
+declare variable $config:packages-col := $config:app-data-col || "/" || $config:packages-col-name;
+declare variable $config:icons-col := $config:app-data-col || "/" || $config:icons-col-name;
+declare variable $config:metadata-col := $config:app-data-col || "/" || $config:metadata-col-name;
+declare variable $config:logs-col := $config:app-data-col || "/" || $config:logs-col-name;
+
+
+declare variable $config:package-groups-doc-name := "package-groups.xml";
+declare variable $config:raw-packages-doc-name := "raw-packages.xml";
+declare variable $config:package-groups-doc := $config:metadata-col || "/" || $config:package-groups-doc-name;
+declare variable $config:raw-packages-doc := $config:metadata-col || "/" || $config:raw-packages-doc-name;
+
+(: The default version number here is assumed when a client does not send a version parameter.
+   It is set to 2.2.0 because this version was the last one known to work with most older packages
+   before packages began to declare their version constraints in their package metadata.
+   So this should stay as 2.2.0 until we (a) no longer have 2.2-era clients or (b) no longer have
+   packages that we care to offer compatibility with 2.2.
+ :)
+declare variable $config:default-exist-version := "2.2.0";
+declare variable $config:exist-processor-name := "http://exist-db.org";
+
+(:~
+ : Returns the repo.xml descriptor for the current application.
+ :)
+declare function config:repo-descriptor() as element(repo:meta) {
+    doc(concat($config:app-root, "/repo.xml"))/repo:meta
+};
+
+(:~
+ : Returns the permissions information from the repo.xml descriptor.
+ :)
+declare function config:repo-permissions() as map(*) { 
+    config:repo-descriptor()/repo:permissions ! 
+        map { 
+            "owner": ./@user/string(), 
+            "group": ./@group/string(),
+            "mode": ./@mode/string()
+        }
+};
+
+(:~
+ : Returns the expath-pkg.xml descriptor for the current application.
+ :)
+declare function config:expath-descriptor() as element(expath:package) {
+    doc(concat($config:app-root, "/expath-pkg.xml"))/expath:package
+};
+
+(:~
+ : For debugging: generates a table showing all properties defined
+ : in the application descriptors.
+ :)
+declare function config:app-info($node as node(), $params as element(parameters)?, $modes as item()*) {
+    let $expath := config:expath-descriptor()
+    let $repo := config:repo-descriptor()
+    return
+        <table class="app-info">
+            <tr>
+                <td>app collection:</td>
+                <td>{$config:app-root}</td>
+            </tr>
+            {
+                for $attr in ($expath/@*, $expath/*, $repo/*)
+                return
+                    <tr>
+                        <td>{node-name($attr)}:</td>
+                        <td>{$attr/string()}</td>
+                    </tr>
+            }
+        </table>
+};


### PR DESCRIPTION
The git-sync.xql has been used for a while to answer the webhook from GitHub, but was not in the repository; here I am adding it. 

In addition, I added a logging module. The first use case is logging of updates through the git-sync.  This is a bit tricky to debug, so I might need several commits to test this out.